### PR TITLE
change to avater of antd on all uses

### DIFF
--- a/client/src/components/GroupCard/GroupCard.tsx
+++ b/client/src/components/GroupCard/GroupCard.tsx
@@ -1,5 +1,5 @@
 import { Avatar, Tooltip, Typography } from 'antd';
-import { CalendarOutlined, DollarOutlined } from '@ant-design/icons';
+import { CalendarOutlined, DollarOutlined, UserOutlined } from '@ant-design/icons';
 import { PopulatedGroup } from '@/models/group.model';
 import { MatchDetails } from '@/components/MatchDetails/MatchDetails';
 import styles from './group-card.module.scss';
@@ -8,6 +8,7 @@ import { PackageFooter } from '@pages/PackagesScreen/PackageFooter';
 import { formattedDate } from '@/utils/date.utils.ts';
 import { useNavigate } from 'react-router-dom';
 import { Package } from '@/models/packages/package.model.ts';
+import { getPictureSrcUrl } from '@/utils/picture.utils';
 
 const { Title, Text } = Typography;
 
@@ -41,7 +42,10 @@ export const GroupCard = ({ group }: GroupCardProps) => {
                 <div className={styles.avatars}>
                     {users.map((member) => (
                         <Tooltip key={member._id} title={member.username}>
-                            <Avatar src={member.picture} />
+                            <Avatar 
+                                src={getPictureSrcUrl(member.picture)}
+                                icon={<UserOutlined />}
+                            />
                         </Tooltip>
                     ))}
                 </div>

--- a/client/src/components/NavbarUserDropdown/NavbarUserDropdown.tsx
+++ b/client/src/components/NavbarUserDropdown/NavbarUserDropdown.tsx
@@ -22,7 +22,7 @@ export const NavbarUserDropdown = ({ showModal, showPreferencesModal }: NavbarUs
                     <div className={classes.profileImageContainer}>
                         <Avatar 
                             className={classes.profileImage}
-                            src={getPictureSrcUrl(loggedInUser.picture)}
+                            src={getPictureSrcUrl(loggedInUser?.picture)}
                             icon={<UserOutlined />}
                         />
                     </div>

--- a/client/src/components/NavbarUserDropdown/NavbarUserDropdown.tsx
+++ b/client/src/components/NavbarUserDropdown/NavbarUserDropdown.tsx
@@ -1,8 +1,8 @@
 import { useAuth } from '@/context/AuthContext';
 import classes from './navbar-user-dropdown.module.scss';
-import { Button, Divider, Dropdown, MenuProps, Typography } from 'antd';
+import { Avatar, Button, Divider, Dropdown, MenuProps, Typography } from 'antd';
 import { getPictureSrcUrl } from '@/utils/picture.utils';
-import { EditOutlined, LogoutOutlined } from '@ant-design/icons';
+import { EditOutlined, LogoutOutlined, UserOutlined } from '@ant-design/icons';
 
 export interface NavbarUserDropdownProps {
     showModal: () => void;
@@ -20,10 +20,10 @@ export const NavbarUserDropdown = ({ showModal, showPreferencesModal }: NavbarUs
             label: loggedInUser ? (
                 <div className={classes.dropdownContainer}>
                     <div className={classes.profileImageContainer}>
-                        <img
-                            src={getPictureSrcUrl(loggedInUser?.picture)}
-                            alt="User Avatar"
+                        <Avatar 
                             className={classes.profileImage}
+                            src={getPictureSrcUrl(loggedInUser.picture)}
+                            icon={<UserOutlined />}
                         />
                     </div>
 
@@ -71,7 +71,11 @@ export const NavbarUserDropdown = ({ showModal, showPreferencesModal }: NavbarUs
     return (
         <Dropdown menu={{ items }} trigger={['click']} placement="bottomRight">
             {loggedInUser && (
-                <img src={getPictureSrcUrl(loggedInUser.picture)} alt="User Avatar" className={classes.avatarSmall} />
+                <Avatar 
+                    src={getPictureSrcUrl(loggedInUser.picture)}
+                    icon={<UserOutlined />}
+                    className={classes.avatarSmall}
+                />
             )}
         </Dropdown>
     );

--- a/client/src/pages/GroupDetailsPage/components/GroupHeader.tsx
+++ b/client/src/pages/GroupDetailsPage/components/GroupHeader.tsx
@@ -4,10 +4,12 @@ import { PopulatedGroup } from '@/models/group.model.ts';
 import { useNavigate } from 'react-router';
 import { ROUTES } from '@/constants/routes.const';
 import { GroupService } from '@/api/services/group.service';
-import { DeleteOutlined, EditOutlined } from '@ant-design/icons';
+import { DeleteOutlined, EditOutlined, UserOutlined } from '@ant-design/icons';
 import classes from '@pages/GroupsScreen/groups-screen.module.scss';
 import { formattedDate } from '@/utils/date.utils.ts';
 import { Calendar, CircleDollarSignIcon } from 'lucide-react';
+import { Avatar } from 'antd';
+import { getPictureSrcUrl } from '@/utils/picture.utils';
 
 interface Props {
     group: PopulatedGroup;
@@ -37,7 +39,10 @@ const GroupHeader: React.FC<Props> = ({ group }) => {
                     <div className="avatars">
                         {users.map((user) => (
                             <div key={user._id} className="avatar-block">
-                                <img src={user.picture} alt={user.username} />
+                                <Avatar 
+                                    src={getPictureSrcUrl(user.picture)}
+                                    icon={<UserOutlined />}
+                                />
                                 <span>{getUserAvatarDisplayName(user.username)}</span>
                             </div>
                         ))}


### PR DESCRIPTION
Profile Avatar Fallback

Updated <Avatar /> to gracefully handle missing or broken profile pictures.

If image loading fails, default icon <UserOutlined /> is displayed automatically.

Uses getPictureSrcUrl() to resolve relative image paths.

**Before:**  
<img width="51" height="47" alt="profilePicBefore" src="https://github.com/user-attachments/assets/8596c6c7-655b-4d4b-b0f9-01b83e8329a2" />

**After:**
<img width="50" height="53" alt="userProfileDefault" src="https://github.com/user-attachments/assets/b3313588-8fea-4c43-889c-258e16024110" />

**Before:**  
<img width="111" height="85" alt="UserDropdownBefore" src="https://github.com/user-attachments/assets/3a73fa5e-eaca-49f7-89c1-0202b7d972b6" />

**After:**
<img width="110" height="84" alt="dropdownafter" src="https://github.com/user-attachments/assets/aba599d8-1e43-4739-8d0f-501ea15dab91" />

**Before:**  
<img width="221" height="102" alt="GroupDetailsBefore" src="https://github.com/user-attachments/assets/2905ba73-6c39-49e3-bfde-cc9e9359fb83" />

**After:**
<img width="217" height="106" alt="GroupCardAfter" src="https://github.com/user-attachments/assets/43472756-35f4-4d76-9ee6-51e34d59886b" />

**Before:**  
<img width="224" height="148" alt="GroupPageBefore" src="https://github.com/user-attachments/assets/145ba87a-5477-41dc-9841-621dff75c789" />

**After:**
<img width="234" height="160" alt="GroupPageAfter" src="https://github.com/user-attachments/assets/53dae90d-ea08-4665-95d8-983426176c3d" />
